### PR TITLE
Adding noAlt support to 1.2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.3.1] - 2026-06-01
+### Added
+- [GRD-1175](https://jira.oicr.on.ca/browse/GRD-1175) Support for hg38_noAlt index
+
+## [1.3.0] - 2026-05-07
+### Added
+- [GBS-6863](https://jira.oicr.on.ca/browse/GBS-6863) - add cram inputs, split the merged cram to lanes (by readgroup) and generate fingerprints for each
+
+## [1.2.2] - 2026-07-30
+### Added
+- [GRD-1175](https://jira.oicr.on.ca/browse/GRD-1175) - added hg38_noAlt support to bam-only version
+- Ensured this version is BAM-only
+
+## [1.2.1] - 2026-07-30
+### Added
+- [GRD-1175](https://jira.oicr.on.ca/browse/GRD-1175) - added hg38_noAlt support to bam-only version
+- THIS VERSION IS BUGGY, CRAM INPUTS ARE STILL IN PLACE.
+
+## [1.2.0] - 2024-06-25
+### Added
+- [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)
+
+
 ## [1.1.0] - 2024-06-25
 ### Added
 - [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ java -jar cromwell.jar run crosscheckFingerprintsCollector.wdl --inputs inputs.j
 #### Required workflow parameters:
 Parameter|Value|Description
 ---|---|---
-`inputType`|String|one of fastq, bam, or cram
+`inputType`|String|one of either fastq or bam
 `aligner`|String|aligner to use for fastq input, either bwa or star
 `markDups`|Boolean|should the alignment be duplicate marked?, generally yes
-`filterBam`|Boolean|should use filterBamToInterval to prefiltering of the bam/cram file to intervals? Generally true
+`filterBam`|Boolean|should use filterBamToInterval to prefiltering of the bam file to intervals? Generally true
 `outputFileNamePrefix`|String|Optional output prefix for the output
 `reference`|String|the reference genome for input sample
 `sampleId`|String|value that will be used as the sample identifier in the vcf fingerprint
@@ -44,9 +44,6 @@ Parameter|Value|Default|Description
 `fastqR2`|File?|None|fastq file for read 2
 `bam`|File?|None|bam file
 `bamIndex`|File?|None|bam index file
-`cram`|File?|None|cram file (may be a merged-lanes cram)
-`cramIndex`|File?|None|index for the cram file
-`is_lane_level`|Boolean|true|true if the input bam/cram is already at lane level; false if it is a merged-lanes file that needs to be split before processing
 `maxReads`|Int|0|The maximum number of reads to process; if set, this will sample the requested number of reads
 
 
@@ -114,198 +111,91 @@ Parameter|Value|Default|Description
 `star.runStar_chimericjunctionSuffix`|String|"Chimeric.out"|Suffix for chimeric junction file
 `star.runStar_transcriptomeSuffix`|String|"Aligned.toTranscriptome.out"|Suffix for transcriptome-aligned file
 `star.runStar_starSuffix`|String|"Aligned.sortedByCoord.out"|Suffix for sorted file
-`filterBamPreSplit.jobMemory`|Int|16|memory allocated for Job
-`filterBamPreSplit.overhead`|Int|6|memory allocated to overhead of the job other than used in markDuplicates command
-`filterBamPreSplit.timeout`|Int|24|Timeout in hours, needed to override imposed limits
-`splitLanes.jobMemory`|Int|16|memory allocated for Job
-`splitLanes.timeout`|Int|24|Timeout in hours, needed to override imposed limits
+`filterBamToIntervals.jobMemory`|Int|16|memory allocated for Job
+`filterBamToIntervals.overhead`|Int|6|memory allocated to overhead of the job other than used in markDuplicates command
+`filterBamToIntervals.timeout`|Int|24|Timeout in hours, needed to override imposed limits
 `splitStringToArray.lineSeparator`|String|","|Interval group separator - these are the intervals to split by.
 `splitStringToArray.recordSeparator`|String|"+"|Interval interval group separator - this can be used to combine multiple intervals into one group.
 `splitStringToArray.jobMemory`|Int|1|Memory allocated to job (in GB).
-`splitStringToArray.threads`|Int|1|The number of threads to allocate to the job.
+`splitStringToArray.cores`|Int|1|The number of cores to allocate to the job.
 `splitStringToArray.timeout`|Int|1|Maximum amount of time (in hours) the task can run for.
 `splitStringToArray.modules`|String|""|Environment module name and version to load (space separated) before command execution.
-`filterBamLane.jobMemory`|Int|16|memory allocated for Job
-`filterBamLane.overhead`|Int|6|memory allocated to overhead of the job other than used in markDuplicates command
-`filterBamLane.timeout`|Int|24|Timeout in hours, needed to override imposed limits
 `markDuplicates.jobMemory`|Int|16|memory allocated for Job
 `markDuplicates.overhead`|Int|6|memory allocated to overhead of the job other than used in markDuplicates command
 `markDuplicates.timeout`|Int|24|Timeout in hours, needed to override imposed limits
-`mergeIntervalBams.additionalParams`|String?|None|Additional parameters to pass to GATK MergeSamFiles.
-`mergeIntervalBams.jobMemory`|Int|24|Memory allocated to job (in GB).
-`mergeIntervalBams.overhead`|Int|6|Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory.
-`mergeIntervalBams.threads`|Int|1|The number of threads to allocate to the job.
-`mergeIntervalBams.timeout`|Int|6|Maximum amount of time (in hours) the task can run for.
-`mergeIntervalBams.modules`|String|"gatk/4.1.6.0"|Environment module name and version to load (space separated) before command execution.
+`mergeBams.additionalParams`|String?|None|Additional parameters to pass to GATK MergeSamFiles.
+`mergeBams.jobMemory`|Int|24|Memory allocated to job (in GB).
+`mergeBams.overhead`|Int|6|Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory.
+`mergeBams.cores`|Int|1|The number of cores to allocate to the job.
+`mergeBams.timeout`|Int|6|Maximum amount of time (in hours) the task can run for.
+`mergeBams.modules`|String|"gatk/4.1.6.0"|Environment module name and version to load (space separated) before command execution.
 `alignmentMetrics.jobMemory`|Int|8|memory allocated for Job
 `alignmentMetrics.timeout`|Int|24|Timeout in hours, needed to override imposed limits
 `extractFingerprint.jobMemory`|Int|8|memory allocated for Job
 `extractFingerprint.timeout`|Int|24|Timeout in hours, needed to override imposed limits
-`fingerprintReadgroupInfo.jobMemory`|Int|8|memory allocated for job
-`fingerprintReadgroupInfo.timeout`|Int|24|timeout in hours
 
 
 ### Outputs
 
 Output | Type | Description | Labels
 ---|---|---|---
-`outputVcf`|Pair[Array[File]+,Map[String,String]]|per-lane crosscheck fingerprint vcf.gz files, file names carry read group|
-`outputTbi`|Pair[Array[File]+,Map[String,String]]|per-lane vcf.gz.tbi index files, file names carry read group|
-`json`|Pair[Array[File]+,Map[String,String]]|per-lane alignment metrics json files, file names carry read group|
-`samstats`|Pair[Array[File]+,Map[String,String]]|per-lane samstats summary files, file names carry read group|
-`readgroupInfo`|Pair[File,Map[String,String]]|JSON array mapping each fingerprint name to the read group tags found in its source bam/cram|
+`outputVcf`|File|the crosscheck fingerprint, gzipped vcf file|vidarr_label: outputVcf
+`outputTbi`|File|index for the vcf fingerprint|vidarr_label: outputTbi
+`json`|File|metrics in json format, currently only the mean coverage for the alignment|vidarr_label: json 
+`samstats`|File|output from the samstats summary|vidarr_label: samstats 
 
 
 ## Commands
-This section lists command(s) run by crosscheckFingerprintsCollector workflow
-
-* Running crosscheckFingerprintsCollector
-
+This section lists command(s) run by CROSSCHECKFINGEPRINTSCOLLECTOR workflow
+  
+* Running CROSSCHECKFINGEPRINTSCOLLECTOR
+  
+### Fingerprint Generation 
+  
 ```
     set -euo pipefail
-    EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-    if [ "$EXT" = "cram" ]; then
-      # samtools split does not support -T; convert CRAM to BAM first
-      ln -s ~{inputBam} input.cram
-      ln -s ~{inputBai} input.cram.crai
-      samtools view -b -T ~{refFasta} -o input_converted.bam input.cram
-      samtools index input_converted.bam
-      samtools split -f "~{outputFileNamePrefix}_%!.bam" input_converted.bam
-    else
-      ln -s ~{inputBam} input.bam
-      ln -s ~{inputBai} input.bam.bai
-      samtools split -f "~{outputFileNamePrefix}_%!.bam" input.bam
-    fi
-    for f in ~{outputFileNamePrefix}_*.bam; do samtools index "$f"; done
+  
+   $GATK_ROOT/bin/gatk ExtractFingerprint \
+                      -R ~{refFasta} \
+                      -H ~{haplotypeMap} \
+                      -I ~{inputBam} \
+                      -O ~{outputFileNamePrefix}.vcf \
+                      --SAMPLE_ALIAS ~{sampleId}
+  
+   $TABIX_ROOT/bin/bgzip -c ~{outputFileNamePrefix}.vcf > ~{outputFileNamePrefix}.vcf.gz
+   $TABIX_ROOT/bin/tabix -p vcf ~{outputFileNamePrefix}.vcf.gz 
 ```
+  
+### downsampling,if requested 
+  
 ```
-  set -euo pipefail
-  EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-  ln -s ~{inputBam} input.$EXT
-  if [ "$EXT" = "cram" ]; then ln -s ~{inputBai} input.cram.crai
-  else                          ln -s ~{inputBai} input.bam.bai
-  fi
-  samtools view -b -T ~{refFasta} -L ~{intervalBed} input.$EXT > ~{outputFileNamePrefix}.filtered.bam
-  samtools index ~{outputFileNamePrefix}.filtered.bam
+   set -euo pipefail
+   
+   seqtk sample -s 100 ~{fastqR1} ~{maxReads} > ~{fastqR1m}
+   gzip ~{fastqR1m}
+   
+   seqtk sample -s 100 ~{fastqR2} ~{maxReads} > ~{fastqR2m}
+   gzip ~{fastqR2m}
 ```
-```
-    set -euo pipefail
-
-    echo "~{str}" | tr '~{lineSeparator}' '\n' | tr '~{recordSeparator}' '\t'
-```
-```
-  set -euo pipefail
-
- $GATK_ROOT/bin/gatk ExtractFingerprint \
-                    -R ~{refFasta} \
-                    -H ~{haplotypeMap} \
-                    -I ~{inputBam} \
-                    -O ~{outputFileNamePrefix}.vcf \
-                    --SAMPLE_ALIAS ~{sampleId}
-
- $TABIX_ROOT/bin/bgzip -c ~{outputFileNamePrefix}.vcf > ~{outputFileNamePrefix}.vcf.gz
- $TABIX_ROOT/bin/tabix -p vcf ~{outputFileNamePrefix}.vcf.gz
-```
-```
- set -euo pipefail
-
- seqtk sample -s 100 ~{fastqR1} ~{maxReads} > ~{fastqR1m}
- gzip ~{fastqR1m}
-
- seqtk sample -s 100 ~{fastqR2} ~{maxReads} > ~{fastqR2m}
- gzip ~{fastqR2m}
-```
-```
-  set -euo pipefail
-  EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-  ln -s ~{inputBam} input.$EXT
-  if [ "$EXT" = "cram" ]; then ln -s ~{inputBai} input.cram.crai
-  else                          ln -s ~{inputBai} input.bam.bai
-  fi
-  samtools view -b -T ~{refFasta} input.$EXT \
-        ~{sep=" " intervals} > intervalBam.bam
-  samtools index intervalBam.bam intervalBam.bam.bai
-
-  $GATK_ROOT/bin/gatk --java-options "-Xmx~{jobMemory - overhead}G" MarkDuplicates \
-                      -I intervalBam.bam \
-                      --METRICS_FILE ~{outputFileNamePrefix}.dupmetrics \
-                      --VALIDATION_STRINGENCY SILENT \
-                      --CREATE_INDEX true \
-                      -O ~{outputFileNamePrefix}.dupmarked.bam
-```
+  
+### Duplicate Marking, if requested 
+  
 ```
     set -euo pipefail
-
-    gatk --java-options "-Xmx~{jobMemory - overhead}G" MergeSamFiles \
-    ~{sep=" " prefix("--INPUT=", bams)} \
-    --OUTPUT="~{outputFileName}~{suffix}.bam" \
-    --CREATE_INDEX=true \
-    --SORT_ORDER=coordinate \
-    --ASSUME_SORTED=false \
-    --USE_THREADING=true \
-    --VALIDATION_STRINGENCY=SILENT \
-    ~{additionalParams}
+    $GATK_ROOT/bin/gatk MarkDuplicates \
+                        -I ~{inputBam} \
+                        --METRICS_FILE ~{outputFileNamePrefix}.dupmetrics \
+                        --VALIDATION_STRINGENCY SILENT \
+                        --CREATE_INDEX true \
+                        -O ~{outputFileNamePrefix}.dupmarked.bam
 ```
-```
-  set -euo pipefail
-
-  ### samtools stats
-  $SAMTOOLS_ROOT/bin/samtools stats --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.samstats.txt
-  reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "raw total sequences:" | cut -f3`
-  mapped_reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads mapped:" | cut -f 3`
-  unmapped_reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads unmapped:" | cut -f 3`
-  mapped_bases=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "bases mapped:" | cut -f 3`
-  reads_duplicated=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads duplicated:" | cut -f 3`
-
-  ### samtools coverage, with duplicates
-  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.coverage.txt
-  mean_cvg=`cat ~{outputFileNamePrefix}.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }'`
-
-  ### samtools coverage, deduplicated
-  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL,DUP --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.dedup.coverage.txt
-  mean_dedup_cvg=`cat ~{outputFileNamePrefix}.dedup.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }'`
-
-  ### json file
-  echo \{\"reads\":$reads,\"mapped_reads\":$mapped_reads,\"unmapped_reads\":$unmapped_reads,\"mapped_bases\":$mapped_bases,\"reads_duplicated\":$reads_duplicated,\"mean_raw_cvg\":$mean_cvg,\"mean_dedup_cvg\":$mean_dedup_cvg\,\"markDups\":~{markDups},\"maxReads\":~{maxReads}} > ~{outputFileNamePrefix}.json
-
-
-```
+  
+### Coverage Assessment 
+  
 ```
     set -euo pipefail
-    python3 << 'PYEOF'
-import subprocess, json, os
-
-bam_paths = '~{sep=" " bams}'.split()
-fp_paths  = '~{sep=" " fingerprints}'.split()
-ref       = '~{refFasta}'
-out_file  = '~{outputFileNamePrefix}.readgroup_info.json'
-
-result = []
-for bam, fp in zip(bam_paths, fp_paths):
-    fp_name = os.path.basename(fp)
-    for ext in ('.vcf.gz', '.vcf'):
-        if fp_name.endswith(ext):
-            fp_name = fp_name[:-len(ext)]
-            break
-
-    proc = subprocess.run(
-        ['samtools', 'view', '-H', '-T', ref, bam],
-        capture_output=True, text=True, check=True
-    )
-
-    for line in proc.stdout.splitlines():
-        if line.startswith('@RG'):
-            fields = line.split('\t')
-            entry = {'fingerprint': fp_name}
-            for field in fields[1:]:
-                tag, _, val = field.partition(':')
-                entry[tag] = val
-            result.append(entry)
-            break
-
-with open(out_file, 'w') as f:
-    json.dump(result, f, indent=2)
-PYEOF
+    $SAMTOOLS_ROOT/bin/samtools coverage ~{inputBam} > ~{outputFileNamePrefix}.coverage.txt
+    cat ~{outputFileNamePrefix}.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}.json
 ```
 ## Support
 

--- a/commands.txt
+++ b/commands.txt
@@ -1,151 +1,52 @@
 ## Commands
-This section lists command(s) run by crosscheckFingerprintsCollector workflow
-
-* Running crosscheckFingerprintsCollector
-
+ This section lists command(s) run by CROSSCHECKFINGEPRINTSCOLLECTOR workflow
+ 
+ * Running CROSSCHECKFINGEPRINTSCOLLECTOR
+ 
+### Fingerprint Generation 
+ 
 ```
-    set -euo pipefail
-    EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-    if [ "$EXT" = "cram" ]; then
-      # samtools split does not support -T; convert CRAM to BAM first
-      ln -s ~{inputBam} input.cram
-      ln -s ~{inputBai} input.cram.crai
-      samtools view -b -T ~{refFasta} -o input_converted.bam input.cram
-      samtools index input_converted.bam
-      samtools split -f "~{outputFileNamePrefix}_%!.bam" input_converted.bam
-    else
-      ln -s ~{inputBam} input.bam
-      ln -s ~{inputBai} input.bam.bai
-      samtools split -f "~{outputFileNamePrefix}_%!.bam" input.bam
-    fi
-    for f in ~{outputFileNamePrefix}_*.bam; do samtools index "$f"; done
+   set -euo pipefail
+ 
+  $GATK_ROOT/bin/gatk ExtractFingerprint \
+                     -R ~{refFasta} \
+                     -H ~{haplotypeMap} \
+                     -I ~{inputBam} \
+                     -O ~{outputFileNamePrefix}.vcf \
+                     --SAMPLE_ALIAS ~{sampleId}
+ 
+  $TABIX_ROOT/bin/bgzip -c ~{outputFileNamePrefix}.vcf > ~{outputFileNamePrefix}.vcf.gz
+  $TABIX_ROOT/bin/tabix -p vcf ~{outputFileNamePrefix}.vcf.gz 
 ```
-```
-  set -euo pipefail
-  EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-  ln -s ~{inputBam} input.$EXT
-  if [ "$EXT" = "cram" ]; then ln -s ~{inputBai} input.cram.crai
-  else                          ln -s ~{inputBai} input.bam.bai
-  fi
-  samtools view -b -T ~{refFasta} -L ~{intervalBed} input.$EXT > ~{outputFileNamePrefix}.filtered.bam
-  samtools index ~{outputFileNamePrefix}.filtered.bam
-```
-```
-    set -euo pipefail
-
-    echo "~{str}" | tr '~{lineSeparator}' '\n' | tr '~{recordSeparator}' '\t'
-```
+ 
+### downsampling,if requested 
+ 
 ```
   set -euo pipefail
-
- $GATK_ROOT/bin/gatk ExtractFingerprint \
-                    -R ~{refFasta} \
-                    -H ~{haplotypeMap} \
-                    -I ~{inputBam} \
-                    -O ~{outputFileNamePrefix}.vcf \
-                    --SAMPLE_ALIAS ~{sampleId}
-
- $TABIX_ROOT/bin/bgzip -c ~{outputFileNamePrefix}.vcf > ~{outputFileNamePrefix}.vcf.gz
- $TABIX_ROOT/bin/tabix -p vcf ~{outputFileNamePrefix}.vcf.gz
+  
+  seqtk sample -s 100 ~{fastqR1} ~{maxReads} > ~{fastqR1m}
+  gzip ~{fastqR1m}
+  
+  seqtk sample -s 100 ~{fastqR2} ~{maxReads} > ~{fastqR2m}
+  gzip ~{fastqR2m}
 ```
+ 
+### Duplicate Marking, if requested 
+ 
 ```
- set -euo pipefail
-
- seqtk sample -s 100 ~{fastqR1} ~{maxReads} > ~{fastqR1m}
- gzip ~{fastqR1m}
-
- seqtk sample -s 100 ~{fastqR2} ~{maxReads} > ~{fastqR2m}
- gzip ~{fastqR2m}
+   set -euo pipefail
+   $GATK_ROOT/bin/gatk MarkDuplicates \
+                       -I ~{inputBam} \
+                       --METRICS_FILE ~{outputFileNamePrefix}.dupmetrics \
+                       --VALIDATION_STRINGENCY SILENT \
+                       --CREATE_INDEX true \
+                       -O ~{outputFileNamePrefix}.dupmarked.bam
 ```
+ 
+### Coverage Assessment 
+ 
 ```
-  set -euo pipefail
-  EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-  ln -s ~{inputBam} input.$EXT
-  if [ "$EXT" = "cram" ]; then ln -s ~{inputBai} input.cram.crai
-  else                          ln -s ~{inputBai} input.bam.bai
-  fi
-  samtools view -b -T ~{refFasta} input.$EXT \
-        ~{sep=" " intervals} > intervalBam.bam
-  samtools index intervalBam.bam intervalBam.bam.bai
-
-  $GATK_ROOT/bin/gatk --java-options "-Xmx~{jobMemory - overhead}G" MarkDuplicates \
-                      -I intervalBam.bam \
-                      --METRICS_FILE ~{outputFileNamePrefix}.dupmetrics \
-                      --VALIDATION_STRINGENCY SILENT \
-                      --CREATE_INDEX true \
-                      -O ~{outputFileNamePrefix}.dupmarked.bam
-```
-```
-    set -euo pipefail
-
-    gatk --java-options "-Xmx~{jobMemory - overhead}G" MergeSamFiles \
-    ~{sep=" " prefix("--INPUT=", bams)} \
-    --OUTPUT="~{outputFileName}~{suffix}.bam" \
-    --CREATE_INDEX=true \
-    --SORT_ORDER=coordinate \
-    --ASSUME_SORTED=false \
-    --USE_THREADING=true \
-    --VALIDATION_STRINGENCY=SILENT \
-    ~{additionalParams}
-```
-```
-  set -euo pipefail
-
-  ### samtools stats
-  $SAMTOOLS_ROOT/bin/samtools stats --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.samstats.txt
-  reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "raw total sequences:" | cut -f3`
-  mapped_reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads mapped:" | cut -f 3`
-  unmapped_reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads unmapped:" | cut -f 3`
-  mapped_bases=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "bases mapped:" | cut -f 3`
-  reads_duplicated=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads duplicated:" | cut -f 3`
-
-  ### samtools coverage, with duplicates
-  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.coverage.txt
-  mean_cvg=`cat ~{outputFileNamePrefix}.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }'`
-
-  ### samtools coverage, deduplicated
-  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL,DUP --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.dedup.coverage.txt
-  mean_dedup_cvg=`cat ~{outputFileNamePrefix}.dedup.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }'`
-
-  ### json file
-  echo \{\"reads\":$reads,\"mapped_reads\":$mapped_reads,\"unmapped_reads\":$unmapped_reads,\"mapped_bases\":$mapped_bases,\"reads_duplicated\":$reads_duplicated,\"mean_raw_cvg\":$mean_cvg,\"mean_dedup_cvg\":$mean_dedup_cvg\,\"markDups\":~{markDups},\"maxReads\":~{maxReads}} > ~{outputFileNamePrefix}.json
-
-
-```
-```
-    set -euo pipefail
-    python3 << 'PYEOF'
-import subprocess, json, os
-
-bam_paths = '~{sep=" " bams}'.split()
-fp_paths  = '~{sep=" " fingerprints}'.split()
-ref       = '~{refFasta}'
-out_file  = '~{outputFileNamePrefix}.readgroup_info.json'
-
-result = []
-for bam, fp in zip(bam_paths, fp_paths):
-    fp_name = os.path.basename(fp)
-    for ext in ('.vcf.gz', '.vcf'):
-        if fp_name.endswith(ext):
-            fp_name = fp_name[:-len(ext)]
-            break
-
-    proc = subprocess.run(
-        ['samtools', 'view', '-H', '-T', ref, bam],
-        capture_output=True, text=True, check=True
-    )
-
-    for line in proc.stdout.splitlines():
-        if line.startswith('@RG'):
-            fields = line.split('\t')
-            entry = {'fingerprint': fp_name}
-            for field in fields[1:]:
-                tag, _, val = field.partition(':')
-                entry[tag] = val
-            result.append(entry)
-            break
-
-with open(out_file, 'w') as f:
-    json.dump(result, f, indent=2)
-PYEOF
+   set -euo pipefail
+   $SAMTOOLS_ROOT/bin/samtools coverage ~{inputBam} > ~{outputFileNamePrefix}.coverage.txt
+   cat ~{outputFileNamePrefix}.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}.json
 ```

--- a/crosscheckFingerprintsCollector.wdl
+++ b/crosscheckFingerprintsCollector.wdl
@@ -56,6 +56,22 @@ workflow crosscheckFingerprintsCollector {
    }
 
 Map[String,GenomeResources] resources = {
+  "hg38_noAlt": {
+    "refFasta" : "$HG38_NOALT_ROOT/hg38_noAlt.fa",
+    "bwaRef" : "$HG38_BWA_INDEX_NOALT_ROOT/hg38_noAlt.fa",
+    "refHapMap" : "$CROSSCHECKFINGERPRINTS_HAPLOTYPE_MAP_ROOT/oicr_hg38_chr.map",
+    "intervalBed": "$CROSSCHECKFINGERPRINTS_HAPLOTYPE_MAP_ROOT/oicr_hg38_intervals.bed",
+    "bwaMemModules" : "samtools/1.9 bwa/0.7.17 hg38-bwa-index-noalt/0.7.17",
+    "starRefDir" : "$HG38_NOALT_STAR_INDEX100_ROOT",
+    "starModules" :"star/2.7.10b hg38-noalt-star-index100/2.7.10b-gencode44",
+    "extractFingerprintModules" : "gatk/4.2.0.0 tabix/0.2.6 hg38-noalt/p12 crosscheckfingerprints-haplotype-map/20230324",
+    "alignmentMetricsModules" : "samtools/1.15 hg38-noalt/p12",
+    "markDuplicatesModules" : "gatk/4.2.0.0 samtools/1.15 hg38-noalt/p12",
+    "downsampleModules" :  "seqtk/1.3",
+    "intervalsToParallelizeByString" : "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
+    "filterBamModules" : "crosscheckfingerprints-haplotype-map/20230324 samtools/1.14 hg38-noalt/p12",
+    "splitLanesModules" : "samtools/1.15 hg38-noalt/p12"
+  },
   "hg38": {
     "refFasta" : "$HG38_ROOT/hg38_random.fa",
     "bwaRef" : "$HG38_BWA_INDEX_ROOT/hg38_random.fa",

--- a/crosscheckFingerprintsCollector.wdl
+++ b/crosscheckFingerprintsCollector.wdl
@@ -22,8 +22,6 @@ struct GenomeResources {
     String markDuplicatesModules
     String downsampleModules
     String intervalBed
-    String filterBamModules
-    String splitLanesModules
 }
 
 workflow crosscheckFingerprintsCollector {
@@ -32,13 +30,10 @@ workflow crosscheckFingerprintsCollector {
         File? fastqR2
         File? bam
         File? bamIndex
-        File? cram
-        File? cramIndex
         String inputType
         String aligner
         Boolean markDups
         Boolean filterBam
-        Boolean is_lane_level = true
         String outputFileNamePrefix
         String reference
         Int maxReads = 0
@@ -49,17 +44,15 @@ workflow crosscheckFingerprintsCollector {
         fastqR2: "fastq file for read 2"
         bam: "bam file"
         bamIndex: "bam index file"
-        cram: "cram file (may be a merged-lanes cram)"
-        cramIndex: "index for the cram file"
-        inputType: "one of fastq, bam, or cram"
-        aligner: "aligner to use for fastq input, either bwa or star"
-        markDups: "should the alignment be duplicate marked?, generally yes"
-        filterBam: "should use filterBamToInterval to prefiltering of the bam/cram file to intervals? Generally true"
-        is_lane_level: "true if the input bam/cram is already at lane level; false if it is a merged-lanes file that needs to be split before processing"
+        inputType: "one of either fastq or bam"
+        aligner : "aligner to use for fastq input, either bwa or star"
+        markDups : "should the alignment be duplicate marked?, generally yes"
+        filterBam: "should use filterBamToInterval to prefiltering of the bam file to intervals? Generally true"
+        intervalsToParallelizeByString : "Comma separated list of intervals to split by (e.g. chr1,chr2,chr3+chr4)."
         outputFileNamePrefix: "Optional output prefix for the output"
-        reference: "the reference genome for input sample"
+        reference : "the reference genome for input sample"
         maxReads: "The maximum number of reads to process; if set, this will sample the requested number of reads"
-        sampleId: "value that will be used as the sample identifier in the vcf fingerprint"
+        sampleId : "value that will be used as the sample identifier in the vcf fingerprint"
    }
 
 Map[String,GenomeResources] resources = {
@@ -88,12 +81,10 @@ Map[String,GenomeResources] resources = {
     "starRefDir" : "$HG38_STAR_INDEX100_ROOT",
     "starModules" :"star/2.7.3a hg38-star-index100/2.7.3a",
     "extractFingerprintModules" : "gatk/4.2.0.0 tabix/0.2.6 hg38/p12 crosscheckfingerprints-haplotype-map/20230324",
-    "alignmentMetricsModules" : "samtools/1.15 hg38/p12",
-    "markDuplicatesModules" : "gatk/4.2.0.0 samtools/1.15 hg38/p12",
+    "alignmentMetricsModules" : "samtools/1.15",
+    "markDuplicatesModules" : "gatk/4.2.0.0 samtools/1.15",
     "downsampleModules" :  "seqtk/1.3",
-    "intervalsToParallelizeByString" : "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-    "filterBamModules" : "crosscheckfingerprints-haplotype-map/20230324 samtools/1.14 hg38/p12",
-    "splitLanesModules" : "samtools/1.15 hg38/p12"
+    "intervalsToParallelizeByString" : "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM"
   },
   "hg19": {
     "refFasta" : "$HG19_ROOT/hg19_random.fa",
@@ -104,17 +95,12 @@ Map[String,GenomeResources] resources = {
     "starRefDir" : "$HG19_STAR_INDEX100_ROOT",
     "starModules" : "star/2.7.3a  hg19-star-index100/2.7.3a",
     "extractFingerprintModules" : "gatk/4.2.0.0 tabix/0.2.6 hg19/p13 crosscheckfingerprints-haplotype-map/20230324",
-    "alignmentMetricsModules" : "samtools/1.15 hg19/p13",
-    "markDuplicatesModules" : "gatk/4.2.0.0 samtools/1.15 hg19/p13",
+    "alignmentMetricsModules" : "samtools/1.15",
+    "markDuplicatesModules" : "gatk/4.2.0.0 samtools/1.15",
     "downsampleModules" :  "seqtk/1.3",
-    "intervalsToParallelizeByString" : "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-    "filterBamModules" : "crosscheckfingerprints-haplotype-map/20230324 samtools/1.14 hg19/p13",
-    "splitLanesModules" : "samtools/1.15 hg19/p13"
+    "intervalsToParallelizeByString" : "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM"
   }}
 
-   # -------------------------------------------------------
-   # Stage 1: Align fastq inputs if needed
-   # -------------------------------------------------------
    if(inputType=="fastq" && defined(fastqR1) && defined(fastqR2)){
      if(maxReads>0){
       call downsample{
@@ -140,12 +126,12 @@ Map[String,GenomeResources] resources = {
       }
 
       if(aligner=="star"){
-       InputGroup starInput = {
+       InputGroup starInput = { 
          "fastqR1": select_first([downsample.fastqR1mod,fastqR1]),
          "fastqR2": select_first([downsample.fastqR2mod,fastqR2]),
          "readGroup": "ID:CROSSCHECK SM:SAMPLE"
        }
-       call star.star {
+       call star.star { 
          input:
            inputGroups = [ starInput ],
            outputFileNamePrefix = outputFileNamePrefix,
@@ -156,152 +142,80 @@ Map[String,GenomeResources] resources = {
      }
    }
 
-   # -------------------------------------------------------
-   # Stage 2: Resolve the initial bam/cram from alignment or
-   #          direct input, then optionally split into lanes.
-   #
-   #   - fastq-derived alignments are already single-lane; no
-   #     splitting is needed regardless of is_lane_level.
-   #   - For bam/cram input with is_lane_level=false, call
-   #     splitLanes to produce one file per read group.
-   #
-   # After this stage, bamsToProcess / baisToProcess are an
-   # Array[File] of length 1 (lane-level) or N (split lanes).
-   # The downstream scatter handles both cases identically,
-   # eliminating duplicated processing logic.
-   # -------------------------------------------------------
-   File initBam = select_first([bwaMem.bwaMemBam, star.starBam, bam, cram])
-   File initBai = select_first([bwaMem.bwaMemIndex, star.starIndex, bamIndex, cramIndex])
-
-   # For merged input: filter to intervals before splitting so splitLanes works
-   # on a much smaller file. Lane-level input is filtered inside the scatter below.
-   if (filterBam && !is_lane_level && inputType != "fastq") {
-     call filterBam as filterBamPreSplit {
-       input:
-         inputBam = initBam,
-         inputBai = initBai,
-         intervalBed = resources[reference].intervalBed,
-         refFasta = resources[reference].refFasta,
+  if(filterBam){
+    call filterBamToIntervals {
+      input:
+         inputBam = select_first([bwaMem.bwaMemBam,star.starBam,bam]),
+         inputBai = select_first([bwaMem.bwaMemIndex,star.starIndex,bamIndex]),
+         intervalBed = resources [ reference].intervalBed,
          outputFileNamePrefix = outputFileNamePrefix,
-         modules = resources[reference].filterBamModules
-     }
-   }
+         modules = "crosscheckfingerprints-haplotype-map/20230324 samtools/1.14"     
+    }
+  }
 
-   if (!is_lane_level && inputType != "fastq") {
-     File splitInput    = select_first([filterBamPreSplit.bam,      initBam])
-     File splitInputBai = select_first([filterBamPreSplit.bamIndex, initBai])
-     call splitLanes {
-       input:
-         inputBam = splitInput,
-         inputBai = splitInputBai,
-         refFasta = resources[reference].refFasta,
-         outputFileNamePrefix = outputFileNamePrefix,
-         modules = resources[reference].splitLanesModules
-     }
-   }
 
-   # Single-element array for lane-level input; multi-element for split lanes.
-   Array[File] bamsToProcess = select_first([splitLanes.laneBams, [initBam]])
-   Array[File] baisToProcess = select_first([splitLanes.laneBamIndexes, [initBai]])
+  if(markDups){
 
-   # -------------------------------------------------------
-   # Stage 3: Per-lane processing (scattered in parallel)
-   #   filterBamToIntervals -> markDuplicates (chr-scatter)
-   #   -> merge chr bams  — all steps are optional and reuse
-   #   the same tasks regardless of lane vs merged input.
-   # -------------------------------------------------------
-   call splitStringToArray {
-     input:
-       str = resources[reference].intervalsToParallelizeByString
-   }
-   Array[Array[String]] intervalsToParallelizeBy = splitStringToArray.out
+    call splitStringToArray {
+      input:
+        str = resources [ reference].intervalsToParallelizeByString
+    }
 
-   scatter (idx in range(length(bamsToProcess))) {
-     String lanePrefix = sub(sub(basename(bamsToProcess[idx]), "\\.bam$", ""), "\\.cram$", "")
+    Array[Array[String]] intervalsToParallelizeBy = splitStringToArray.out
 
-     if (filterBam) {
-       call filterBam as filterBamLane {
-         input:
-           inputBam = bamsToProcess[idx],
-           inputBai = baisToProcess[idx],
-           intervalBed = resources[reference].intervalBed,
-           refFasta = resources[reference].refFasta,
-           outputFileNamePrefix = lanePrefix,
-           modules = resources[reference].filterBamModules
-       }
-     }
-
-     if (markDups) {
-       scatter (intervals in intervalsToParallelizeBy) {
-         call markDuplicates {
-           input:
-             inputBam = select_first([filterBamLane.bam, bamsToProcess[idx]]),
-             inputBai = select_first([filterBamLane.bamIndex, baisToProcess[idx]]),
-             outputFileNamePrefix = lanePrefix,
-             intervals = intervals,
-             refFasta = resources[reference].refFasta,
-             modules = resources[reference].markDuplicatesModules
-         }
-       }
-       call mergeBams as mergeIntervalBams {
-         input:
-           bams = markDuplicates.bam,
-           outputFileName = lanePrefix,
-           suffix = ""
-       }
-     }
-
-     # Best available output for this lane, in priority order:
-     #   markDups merged > filterBam filtered > original lane bam
-     File laneResult      = select_first([mergeIntervalBams.mergedBam,      filterBamLane.bam,      bamsToProcess[idx]])
-     File laneResultIndex = select_first([mergeIntervalBams.mergedBamIndex, filterBamLane.bamIndex, baisToProcess[idx]])
-
-     # -------------------------------------------------------
-     # Stage 4: Metrics and fingerprint — one per lane bam
-     # -------------------------------------------------------
-     call alignmentMetrics {
-       input:
-          inputBam = laneResult,
-          inputBai = laneResultIndex,
-          outputFileNamePrefix = lanePrefix,
-          markDups = markDups,
-          maxReads = maxReads,
-          refFasta = resources[reference].refFasta,
-          modules = resources[reference].alignmentMetricsModules
-     }
-
-     call extractFingerprint {
-       input:
-          inputBam = laneResult,
-          inputBai = laneResultIndex,
-          haplotypeMap = resources[reference].refHapMap,
-          refFasta = resources[reference].refFasta,
-          outputFileNamePrefix = lanePrefix,
-          sampleId = sampleId,
-          modules = resources[reference].extractFingerprintModules
+    scatter (intervals in intervalsToParallelizeBy){
+      call markDuplicates {
+        input :
+          inputBam = select_first([filterBamToIntervals.bam,bwaMem.bwaMemBam,star.starBam,bam]),
+          inputBai = select_first([filterBamToIntervals.bamIndex,bwaMem.bwaMemIndex,star.starIndex,bamIndex]),
+          outputFileNamePrefix = outputFileNamePrefix,
+          intervals = intervals,
+          modules = resources [ reference ].markDuplicatesModules 
       }
-   }
+    }
+    Array[File] markDuplicatedBams = markDuplicates.bam
+    
+	
+	call mergeBams {
+      input:
+      bams = markDuplicatedBams,
+      outputFileName = outputFileNamePrefix,
+      suffix = ""
+    }
+  }
 
-   call fingerprintReadgroupInfo {
+  
+   call alignmentMetrics {
      input:
-       bams                 = laneResult,
-       fingerprints         = extractFingerprint.vgz,
-       refFasta             = resources[reference].refFasta,
-       outputFileNamePrefix = outputFileNamePrefix,
-       modules              = resources[reference].alignmentMetricsModules
+        inputBam = select_first([mergeBams.mergedBam,filterBamToIntervals.bam,bwaMem.bwaMemBam,star.starBam,bam]),
+        inputBai = select_first([mergeBams.mergedBamIndex,filterBamToIntervals.bamIndex,bwaMem.bwaMemIndex,star.starIndex,bamIndex]),
+        outputFileNamePrefix = outputFileNamePrefix,
+        markDups = markDups,
+        maxReads = maxReads,
+        modules = resources [ reference ].alignmentMetricsModules  
    }
+   
+   call extractFingerprint {
+     input:
+        inputBam = select_first([mergeBams.mergedBam,filterBamToIntervals.bam,bwaMem.bwaMemBam,star.starBam,bam]),
+        inputBai = select_first([mergeBams.mergedBamIndex,filterBamToIntervals.bamIndex,star.starIndex,bamIndex]),
+        haplotypeMap = resources [ reference ].refHapMap,
+        refFasta =  resources [ reference ].refFasta,
+        outputFileNamePrefix = outputFileNamePrefix,
+        sampleId = sampleId,
+        modules = resources [ reference ].extractFingerprintModules
+    }
 
    output {
-      Pair[Array[File]+, Map[String,String]] outputVcf    = (extractFingerprint.vgz,        {"vidarr_label": "outputVcf"})
-      Pair[Array[File]+, Map[String,String]] outputTbi    = (extractFingerprint.tbi,         {"vidarr_label": "outputTbi"})
-      Pair[Array[File]+, Map[String,String]] json         = (alignmentMetrics.json,          {"vidarr_label": "json"})
-      Pair[Array[File]+, Map[String,String]] samstats     = (alignmentMetrics.samstats,      {"vidarr_label": "samstats"})
-      Pair[File,         Map[String,String]] readgroupInfo = (fingerprintReadgroupInfo.json,  {"vidarr_label": "readgroupInfo"})
-   }
+      File outputVcf = extractFingerprint.vgz
+      File outputTbi = extractFingerprint.tbi
+      File json = alignmentMetrics.json
+      File samstats = alignmentMetrics.samstats
+     }
 
     meta {
-     author: "Lawrence Heisler, Gavin Peng"
-     email: "lawrence.heisler@oicr.on.ca, gpeng@oicr.on.ca"
+     author: "Lawrence Heisler"
+     email: "lawrence.heisler@oicr.on.ca"
      description: "crosscheckFingerprintsCollector, workflow that generates genotype fingerprints using gatk ExtractFingprint.  Output are vcf files that can be proccessed through gatk Crosscheck fingerprints\n##"
      dependencies: [
       {
@@ -323,7 +237,7 @@ Map[String,GenomeResources] resources = {
       { name: "gsi crosscheckfingerprints-haplotype-map module",
         url: "https://gitlab.oicr.on.ca/ResearchIT/modulator"
       },
-      {
+      { 
         name: "gsi hg38 modules : hg38/p12 hg38-bwa-index-with-alt/0.7.17 hg38-star-index100/2.7.3a",
         url: "https://gitlab.oicr.on.ca/ResearchIT/modulator"
       },
@@ -334,19 +248,24 @@ Map[String,GenomeResources] resources = {
      ]
      output_meta: {
      outputVcf: {
-         description: "per-lane crosscheck fingerprint vcf.gz files, file names carry read group"
+         description: "the crosscheck fingerprint, gzipped vcf file",
+         vidarr_label: "outputVcf"
      },
      outputTbi: {
-         description: "per-lane vcf.gz.tbi index files, file names carry read group"
+         description: "index for the vcf fingerprint",
+         vidarr_label: "outputTbi"
+     },
+     coverage: {
+         description: "output from samtools coverage, with per chromosome metrics",
+         vidarr_label: "coverage"
      },
      json: {
-         description: "per-lane alignment metrics json files, file names carry read group"
+         description: "metrics in json format, currently only the mean coverage for the alignment",
+         vidarr_label: "json"
      },
      samstats: {
-         description: "per-lane samstats summary files, file names carry read group"
-     },
-     readgroupInfo: {
-         description: "JSON array mapping each fingerprint name to the read group tags found in its source bam/cram"
+         description: "output from the samstats summary",
+         vidarr_label: "samstats"
      }
      }
   }
@@ -354,74 +273,17 @@ Map[String,GenomeResources] resources = {
 
 
 
-
-
 # ==========================================
-#  Split a merged bam/cram into per-lane bam
-#  files using samtools split (by read group)
+#  Filter Bam to Intervals
 # ==========================================
 
-task splitLanes {
-  input {
-    File inputBam
-    File inputBai
-    String refFasta
-    String outputFileNamePrefix
-    String modules
-    Int jobMemory = 16
-    Int timeout = 24
-  }
-  parameter_meta {
-    inputBam: "input .bam or .cram file to split by read group"
-    inputBai: "index for the input file (.bai or .crai)"
-    refFasta: "path to reference FASTA (required for CRAM input)"
-    outputFileNamePrefix: "prefix for output lane bam files"
-    modules: "Names and versions of modules"
-    jobMemory: "memory allocated for Job"
-    timeout: "Timeout in hours, needed to override imposed limits"
-  }
-
-  command <<<
-    set -euo pipefail
-    EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-    if [ "$EXT" = "cram" ]; then
-      # samtools split does not support -T; convert CRAM to BAM first
-      ln -s ~{inputBam} input.cram
-      ln -s ~{inputBai} input.cram.crai
-      samtools view -b -T ~{refFasta} -o input_converted.bam input.cram
-      samtools index input_converted.bam
-      samtools split -f "~{outputFileNamePrefix}_%!.bam" input_converted.bam
-    else
-      ln -s ~{inputBam} input.bam
-      ln -s ~{inputBai} input.bam.bai
-      samtools split -f "~{outputFileNamePrefix}_%!.bam" input.bam
-    fi
-    for f in ~{outputFileNamePrefix}_*.bam; do samtools index "$f"; done
-  >>>
-
-  output {
-    Array[File] laneBams       = glob("~{outputFileNamePrefix}_*.bam")
-    Array[File] laneBamIndexes = glob("~{outputFileNamePrefix}_*.bam.bai")
-  }
-
-  runtime {
-    memory:  "~{jobMemory} GB"
-    modules: "~{modules}"
-    timeout: "~{timeout}"
-  }
-}
 
 
-# ==========================================
-#  Filter Bam/Cram to Intervals
-# ==========================================
-
-task filterBam {
+task filterBamToIntervals {
  input{
   File inputBam
   File inputBai
   String intervalBed
-  String refFasta
   String modules
   String outputFileNamePrefix
   Int jobMemory = 16
@@ -429,24 +291,18 @@ task filterBam {
   Int timeout = 24
  }
  parameter_meta {
-  inputBam: "input .bam or .cram file"
-  inputBai: "index of the input file"
-  outputFileNamePrefix: "prefix for making names for output files"
-  refFasta: "path to reference FASTA (required for CRAM input, harmless for BAM)"
+  inputBam: "input .bam file"
+  inputBai: "index of the input .bam file"
+  outputFileNamePrefix: "prefix for making names for output files"  
   jobMemory: "memory allocated for Job"
   overhead: "memory allocated to overhead of the job other than used in markDuplicates command"
   modules: "Names and versions of modules"
   timeout: "Timeout in hours, needed to override imposed limits"
  }
-
+ 
 command <<<
   set -euo pipefail
-  EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-  ln -s ~{inputBam} input.$EXT
-  if [ "$EXT" = "cram" ]; then ln -s ~{inputBai} input.cram.crai
-  else                          ln -s ~{inputBai} input.bam.bai
-  fi
-  samtools view -b -T ~{refFasta} -L ~{intervalBed} input.$EXT > ~{outputFileNamePrefix}.filtered.bam
+  samtools view -b ~{inputBam} -L ~{intervalBed} > ~{outputFileNamePrefix}.filtered.bam
   samtools index ~{outputFileNamePrefix}.filtered.bam
 >>>
 
@@ -457,10 +313,12 @@ command <<<
  }
 
  output {
-  File bam      = "~{outputFileNamePrefix}.filtered.bam"
+  File bam = "~{outputFileNamePrefix}.filtered.bam"
   File bamIndex = "~{outputFileNamePrefix}.filtered.bam.bai"
  }
 }
+
+
 
 
 
@@ -474,7 +332,7 @@ task splitStringToArray {
     String recordSeparator = "+"
 
     Int jobMemory = 1
-    Int threads = 1
+    Int cores = 1
     Int timeout = 1
     String modules = ""
   }
@@ -491,7 +349,7 @@ task splitStringToArray {
 
   runtime {
     memory: "~{jobMemory} GB"
-    cpu: "~{threads}"
+    cpu: "~{cores}"
     timeout: "~{timeout}"
     modules: "~{modules}"
   }
@@ -501,7 +359,7 @@ task splitStringToArray {
     lineSeparator: "Interval group separator - these are the intervals to split by."
     recordSeparator: "Interval interval group separator - this can be used to combine multiple intervals into one group."
     jobMemory: "Memory allocated to job (in GB)."
-    threads: "The number of threads to allocate to the job."
+    cores: "The number of cores to allocate to the job."
     timeout: "Maximum amount of time (in hours) the task can run for."
     modules: "Environment module name and version to load (space separated) before command execution."
   }
@@ -511,6 +369,7 @@ task splitStringToArray {
 # ==========================================
 #  configure and run extractFingerprintsCollector
 # ==========================================
+
 
 task extractFingerprint {
 input {
@@ -547,7 +406,7 @@ command <<<
                     --SAMPLE_ALIAS ~{sampleId}
 
  $TABIX_ROOT/bin/bgzip -c ~{outputFileNamePrefix}.vcf > ~{outputFileNamePrefix}.vcf.gz
- $TABIX_ROOT/bin/tabix -p vcf ~{outputFileNamePrefix}.vcf.gz
+ $TABIX_ROOT/bin/tabix -p vcf ~{outputFileNamePrefix}.vcf.gz 
 >>>
 
  runtime {
@@ -569,6 +428,7 @@ command <<<
 #  downsample the fastq files to the first N reads
 # ==========================================
 
+
 task downsample {
  input{
   File fastqR1
@@ -578,7 +438,7 @@ task downsample {
   Int jobMemory = 8
   Int timeout = 24
  }
-
+ 
  parameter_meta {
   fastqR1 : "Read1 fastq file"
   fastqR2 : "Read2 fastq file"
@@ -587,16 +447,16 @@ task downsample {
   modules: "Names and versions of modules"
   timeout: "Timeout in hours, needed to override imposed limits"
  }
-
+ 
  String fastqR1m = basename(fastqR1,".fastq.gz") + ".mod.fastq"
  String fastqR2m = basename(fastqR2,".fastq.gz") + ".mod.fastq"
-
+  
 command <<<
  set -euo pipefail
-
+ 
  seqtk sample -s 100 ~{fastqR1} ~{maxReads} > ~{fastqR1m}
  gzip ~{fastqR1m}
-
+ 
  seqtk sample -s 100 ~{fastqR2} ~{maxReads} > ~{fastqR2m}
  gzip ~{fastqR2m}
 >>>
@@ -610,7 +470,7 @@ command <<<
  output {
   File fastqR1mod = "~{fastqR1m}.gz"
   File fastqR2mod = "~{fastqR2m}.gz"
- }
+ }    
 }
 
 
@@ -618,11 +478,12 @@ command <<<
 #  Duplicate Marking
 # ==========================================
 
+
+
 task markDuplicates {
  input{
   File inputBam
   File inputBai
-  String refFasta
   String modules
   String outputFileNamePrefix
   Array[String] intervals
@@ -631,24 +492,21 @@ task markDuplicates {
   Int timeout = 24
  }
  parameter_meta {
-  inputBam: "input .bam or .cram file"
-  inputBai: "index of the input file"
-  refFasta: "path to reference FASTA (required for CRAM input, harmless for BAM)"
-  outputFileNamePrefix: "prefix for making names for output files"
+  inputBam: "input .bam file"
+  inputBai: "index of the input .bam file"
+  outputFileNamePrefix: "prefix for making names for output files"  
   jobMemory: "memory allocated for Job"
   overhead: "memory allocated to overhead of the job other than used in markDuplicates command"
   modules: "Names and versions of modules"
   timeout: "Timeout in hours, needed to override imposed limits"
  }
-
+ 
 command <<<
   set -euo pipefail
-  EXT=$(basename ~{inputBam} | rev | cut -d. -f1 | rev)
-  ln -s ~{inputBam} input.$EXT
-  if [ "$EXT" = "cram" ]; then ln -s ~{inputBai} input.cram.crai
-  else                          ln -s ~{inputBai} input.bam.bai
-  fi
-  samtools view -b -T ~{refFasta} input.$EXT \
+  ln -s ~{inputBam} inputBam.bam
+  ln -s ~{inputBai} inputBam.bam.bai
+  samtools view -b \
+        inputBam.bam \
         ~{sep=" " intervals} > intervalBam.bam
   samtools index intervalBam.bam intervalBam.bam.bai
 
@@ -684,7 +542,7 @@ task mergeBams {
 
     Int jobMemory = 24
     Int overhead = 6
-    Int threads = 1
+    Int cores = 1
     Int timeout = 6
     String modules = "gatk/4.1.6.0"
   }
@@ -704,13 +562,13 @@ task mergeBams {
   >>>
 
   output {
-    File mergedBam      = "~{outputFileName}~{suffix}.bam"
+    File mergedBam = "~{outputFileName}~{suffix}.bam"
     File mergedBamIndex = "~{outputFileName}~{suffix}.bai"
   }
 
   runtime {
     memory: "~{jobMemory} GB"
-    cpu: "~{threads}"
+    cpu: "~{cores}"
     timeout: "~{timeout}"
     modules: "~{modules}"
   }
@@ -721,7 +579,7 @@ task mergeBams {
     additionalParams: "Additional parameters to pass to GATK MergeSamFiles."
     jobMemory: "Memory allocated to job (in GB)."
     overhead: "Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory."
-    threads: "The number of threads to allocate to the job."
+    cores: "The number of cores to allocate to the job."
     timeout: "Maximum amount of time (in hours) the task can run for."
     modules: "Environment module name and version to load (space separated) before command execution."
   }
@@ -732,11 +590,11 @@ task mergeBams {
 #  coverage metrics from the bam file used for fingerprint analysis
 # ==========================================
 
+
  task alignmentMetrics{
    input{
     File inputBam
     File inputBai
-    String refFasta
     String modules
     String outputFileNamePrefix
     Boolean markDups
@@ -747,19 +605,18 @@ task mergeBams {
    parameter_meta {
     inputBam: "input .bam file"
     inputBai: "index of the input .bam file"
-    refFasta: "path to reference FASTA (required for CRAM input, harmless for BAM)"
-    outputFileNamePrefix: "prefix for making names for output files"
+    outputFileNamePrefix: "prefix for making names for output files"  
     jobMemory: "memory allocated for Job"
     modules: "Names and versions of modules"
-    maxReads: "the maximum number of reads to use"
+    maxReads : "the maximum number of reads to use"
     timeout: "Timeout in hours, needed to override imposed limits"
-   }
+   } 
 
 command <<<
   set -euo pipefail
 
   ### samtools stats
-  $SAMTOOLS_ROOT/bin/samtools stats --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.samstats.txt
+  $SAMTOOLS_ROOT/bin/samtools stats ~{inputBam} > ~{outputFileNamePrefix}.samstats.txt
   reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "raw total sequences:" | cut -f3`
   mapped_reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads mapped:" | cut -f 3`
   unmapped_reads=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads unmapped:" | cut -f 3`
@@ -767,15 +624,16 @@ command <<<
   reads_duplicated=`cat ~{outputFileNamePrefix}.samstats.txt | grep ^SN | grep "reads duplicated:" | cut -f 3`
 
   ### samtools coverage, with duplicates
-  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.coverage.txt
+  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL ~{inputBam} > ~{outputFileNamePrefix}.coverage.txt
   mean_cvg=`cat ~{outputFileNamePrefix}.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }'`
-
+  
   ### samtools coverage, deduplicated
-  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL,DUP --reference ~{refFasta} ~{inputBam} > ~{outputFileNamePrefix}.dedup.coverage.txt
+  $SAMTOOLS_ROOT/bin/samtools coverage --ff UNMAP,SECONDARY,QCFAIL,DUP ~{inputBam} > ~{outputFileNamePrefix}.dedup.coverage.txt
   mean_dedup_cvg=`cat ~{outputFileNamePrefix}.dedup.coverage.txt | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }'`
-
+  
   ### json file
   echo \{\"reads\":$reads,\"mapped_reads\":$mapped_reads,\"unmapped_reads\":$unmapped_reads,\"mapped_bases\":$mapped_bases,\"reads_duplicated\":$reads_duplicated,\"mean_raw_cvg\":$mean_cvg,\"mean_dedup_cvg\":$mean_dedup_cvg\,\"markDups\":~{markDups},\"maxReads\":~{maxReads}} > ~{outputFileNamePrefix}.json
+
 
 
 >>>
@@ -787,82 +645,7 @@ command <<<
   }
 
   output {
-    File json     = "~{outputFileNamePrefix}.json"
+    File json = "~{outputFileNamePrefix}.json"
     File samstats = "~{outputFileNamePrefix}.samstats.txt"
-  }
-}
-
-
-# ==========================================
-#  Build a JSON array that maps each fingerprint
-#  name to the @RG tags found in its source bam/cram
-# ==========================================
-
-task fingerprintReadgroupInfo {
-  input {
-    Array[File] bams
-    Array[File] fingerprints
-    String refFasta
-    String outputFileNamePrefix
-    String modules
-    Int jobMemory = 8
-    Int timeout = 24
-  }
-  parameter_meta {
-    bams:                 "lane-level bam/cram files used for fingerprint extraction (parallel to fingerprints)"
-    fingerprints:         "fingerprint vcf.gz files (parallel to bams)"
-    refFasta:             "path to reference FASTA (required for CRAM decoding)"
-    outputFileNamePrefix: "prefix for the output JSON file"
-    modules:              "Names and versions of modules"
-    jobMemory:            "memory allocated for job"
-    timeout:              "timeout in hours"
-  }
-
-  command <<<
-    set -euo pipefail
-    python3 << 'PYEOF'
-import subprocess, json, os
-
-bam_paths = '~{sep=" " bams}'.split()
-fp_paths  = '~{sep=" " fingerprints}'.split()
-ref       = '~{refFasta}'
-out_file  = '~{outputFileNamePrefix}.readgroup_info.json'
-
-result = []
-for bam, fp in zip(bam_paths, fp_paths):
-    fp_name = os.path.basename(fp)
-    for ext in ('.vcf.gz', '.vcf'):
-        if fp_name.endswith(ext):
-            fp_name = fp_name[:-len(ext)]
-            break
-
-    proc = subprocess.run(
-        ['samtools', 'view', '-H', '-T', ref, bam],
-        capture_output=True, text=True, check=True
-    )
-
-    for line in proc.stdout.splitlines():
-        if line.startswith('@RG'):
-            fields = line.split('\t')
-            entry = {'fingerprint': fp_name}
-            for field in fields[1:]:
-                tag, _, val = field.partition(':')
-                entry[tag] = val
-            result.append(entry)
-            break
-
-with open(out_file, 'w') as f:
-    json.dump(result, f, indent=2)
-PYEOF
-  >>>
-
-  output {
-    File json = "~{outputFileNamePrefix}.readgroup_info.json"
-  }
-
-  runtime {
-    memory:  "~{jobMemory} GB"
-    modules: "~{modules}"
-    timeout: "~{timeout}"
   }
 }

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -7,5 +7,5 @@ set -o pipefail
 cd $1
 
 #find all files, return their md5sums to std out
-find . -name "*.vcf.gz" -xtype f -exec sh -c "zcat {} | grep -v ^# | md5sum" \;
+find . -name *.vcf.gz -xtype f -exec sh -c "zcat {} | grep -v ^# | md5sum" \;
 ls | sed 's/.*\.//' | sort | uniq -c

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -33,9 +33,9 @@
       "crosscheckFingerprintsCollector.sampleId" : "TEST_0001_WG_HG38_FASTQ",
       "crosscheckFingerprintsCollector.aligner": "bwa",
       "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": 16,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": 6,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": 24,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.jobMemory": 16,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.overhead": 6,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.timeout": 24,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
       "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
@@ -113,7 +113,7 @@
       "crosscheckFingerprintsCollector.markDuplicates.overhead" : 6,
       "crosscheckFingerprintsCollector.alignmentMetrics.timeout" : null,
       "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory" : null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
+      "crosscheckFingerprintsCollector.splitStringToArray.cores": null,
       "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
       "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
       "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
@@ -122,25 +122,9 @@
       "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
       "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
       "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
+      "crosscheckFingerprintsCollector.mergeBams.cores": null,
       "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.cram": null,
-      "crosscheckFingerprintsCollector.cramIndex": null,
-      "crosscheckFingerprintsCollector.is_lane_level": true,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
+      "crosscheckFingerprintsCollector.mergeBams.modules": null
     },
     "engineArguments": {
       "write_to_cache": false,
@@ -178,21 +162,13 @@
           }
         ],
         "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
       }
     },
     "validators": [
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WG_HG38_FASTQ.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/TEST_0001_WG_HG38_FASTQ.metrics",
         "type": "script"
       }
     ]
@@ -231,9 +207,9 @@
       "crosscheckFingerprintsCollector.sampleId" : "TEST_0001_WT_HG38_FASTQ",
       "crosscheckFingerprintsCollector.aligner": "star",
       "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.jobMemory": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.overhead": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
       "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
@@ -311,7 +287,7 @@
       "crosscheckFingerprintsCollector.markDuplicates.overhead" : 6,
       "crosscheckFingerprintsCollector.alignmentMetrics.timeout" : null,
       "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory" : null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
+      "crosscheckFingerprintsCollector.splitStringToArray.cores": null,
       "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
       "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
       "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
@@ -320,25 +296,9 @@
       "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
       "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
       "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
+      "crosscheckFingerprintsCollector.mergeBams.cores": null,
       "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.cram": null,
-      "crosscheckFingerprintsCollector.cramIndex": null,
-      "crosscheckFingerprintsCollector.is_lane_level": true,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
+      "crosscheckFingerprintsCollector.mergeBams.modules": null
     },
     "engineArguments": {
       "write_to_cache": false,
@@ -376,21 +336,13 @@
           }
         ],
         "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
       }
     },
     "validators": [
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WT_HG38_FASTQ.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/TEST_0001_WT_HG38_FASTQ.metrics",
         "type": "script"
       }
     ]
@@ -429,9 +381,9 @@
       "crosscheckFingerprintsCollector.sampleId" : "TEST_0001_WG_HG38_FASTQ_MAXREADS",
       "crosscheckFingerprintsCollector.aligner": "bwa",
       "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.jobMemory": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.overhead": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
       "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
@@ -509,7 +461,7 @@
       "crosscheckFingerprintsCollector.markDuplicates.overhead" : 6,
       "crosscheckFingerprintsCollector.alignmentMetrics.timeout" : null,
       "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory" : null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
+      "crosscheckFingerprintsCollector.splitStringToArray.cores": null,
       "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
       "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
       "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
@@ -518,25 +470,9 @@
       "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
       "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
       "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
+      "crosscheckFingerprintsCollector.mergeBams.cores": null,
       "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.cram": null,
-      "crosscheckFingerprintsCollector.cramIndex": null,
-      "crosscheckFingerprintsCollector.is_lane_level": true,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
+      "crosscheckFingerprintsCollector.mergeBams.modules": null
     },
     "engineArguments": {
       "write_to_cache": false,
@@ -574,21 +510,13 @@
           }
         ],
         "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
       }
     },
     "validators": [
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WG_HG38_FASTQ_MAXREADS.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/TEST_0001_WG_HG38_FASTQ_MAXREADS.metrics",
         "type": "script"
       }
     ]
@@ -627,9 +555,9 @@
       "crosscheckFingerprintsCollector.sampleId" : "TEST_0001_WT_HG38_FASTQ_MAXREADS",
       "crosscheckFingerprintsCollector.aligner": "star",
       "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.jobMemory": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.overhead": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
       "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
@@ -707,7 +635,7 @@
       "crosscheckFingerprintsCollector.markDuplicates.overhead" : 6,
       "crosscheckFingerprintsCollector.alignmentMetrics.timeout" : null,
       "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory" : null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
+      "crosscheckFingerprintsCollector.splitStringToArray.cores": null,
       "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
       "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
       "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
@@ -716,25 +644,9 @@
       "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
       "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
       "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
+      "crosscheckFingerprintsCollector.mergeBams.cores": null,
       "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.cram": null,
-      "crosscheckFingerprintsCollector.cramIndex": null,
-      "crosscheckFingerprintsCollector.is_lane_level": true,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
+      "crosscheckFingerprintsCollector.mergeBams.modules": null
     },
     "engineArguments": {
       "write_to_cache": false,
@@ -772,21 +684,13 @@
           }
         ],
         "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
       }
     },
     "validators": [
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WT_HG38_FASTQ_MAXREADS.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/TEST_0001_WT_HG38_FASTQ_MAXREADS.metrics",
         "type": "script"
       }
     ]
@@ -825,9 +729,9 @@
       "crosscheckFingerprintsCollector.sampleId" : "TEST_0001_WG_HG38_BAM",
       "crosscheckFingerprintsCollector.aligner": "bwa",
       "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.jobMemory": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.overhead": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
       "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
@@ -905,7 +809,7 @@
       "crosscheckFingerprintsCollector.markDuplicates.overhead" : 6,
       "crosscheckFingerprintsCollector.alignmentMetrics.timeout" : null,
       "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory" : null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
+      "crosscheckFingerprintsCollector.splitStringToArray.cores": null,
       "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
       "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
       "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
@@ -914,25 +818,9 @@
       "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
       "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
       "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
+      "crosscheckFingerprintsCollector.mergeBams.cores": null,
       "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.cram": null,
-      "crosscheckFingerprintsCollector.cramIndex": null,
-      "crosscheckFingerprintsCollector.is_lane_level": true,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
+      "crosscheckFingerprintsCollector.mergeBams.modules": null
     },
     "engineArguments": {
       "write_to_cache": false,
@@ -970,21 +858,13 @@
           }
         ],
         "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
       }
     },
     "validators": [
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WG_HG38_BAM.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/TEST_0001_WG_HG38_BAM.metrics",
         "type": "script"
       }
     ]
@@ -1023,9 +903,9 @@
       "crosscheckFingerprintsCollector.sampleId" : "TEST_0001_WT_HG38_BAM",
       "crosscheckFingerprintsCollector.aligner": "star",
       "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.jobMemory": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.overhead": null,
+      "crosscheckFingerprintsCollector.filterBamToIntervals.timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
       "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
       "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
@@ -1103,7 +983,7 @@
       "crosscheckFingerprintsCollector.markDuplicates.overhead" : 6,
       "crosscheckFingerprintsCollector.alignmentMetrics.timeout" : null,
       "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory" : null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
+      "crosscheckFingerprintsCollector.splitStringToArray.cores": null,
       "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
       "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
       "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
@@ -1112,25 +992,9 @@
       "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
       "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
       "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
+      "crosscheckFingerprintsCollector.mergeBams.cores": null,
       "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.cram": null,
-      "crosscheckFingerprintsCollector.cramIndex": null,
-      "crosscheckFingerprintsCollector.is_lane_level": true,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
+      "crosscheckFingerprintsCollector.mergeBams.modules": null
     },
     "engineArguments": {
       "write_to_cache": false,
@@ -1168,222 +1032,15 @@
           }
         ],
         "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
       }
     },
     "validators": [
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WT_HG38_BAM.metrics",
-        "type": "script"
-      }
-    ]
-  },
-  {
-    "id": "TEST_0001_WG_HG38_CRAM_MULTILANE",
-    "description": "runs the crosscheckFingerprintsCollector workflow on a WG library using hg38, with a merged-lanes cram as input (is_lane_level=false), exercises splitLanes and per-lane scatter",
-    "arguments": {
-      "crosscheckFingerprintsCollector.cram": {
-        "contents": {
-          "configuration": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/input_data/test_2lanes.cram",
-          "externalIds": [
-            {
-              "id": "TEST",
-              "provider": "TEST"
-            }
-          ]
-        },
-        "type": "EXTERNAL"
-      },
-      "crosscheckFingerprintsCollector.cramIndex": {
-        "contents": {
-          "configuration": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/input_data/test_2lanes.cram.crai",
-          "externalIds": [
-            {
-              "id": "TEST",
-              "provider": "TEST"
-            }
-          ]
-        },
-        "type": "EXTERNAL"
-      },
-      "crosscheckFingerprintsCollector.inputType": "cram",
-      "crosscheckFingerprintsCollector.filterBam": true,
-      "crosscheckFingerprintsCollector.is_lane_level": false,
-      "crosscheckFingerprintsCollector.outputFileNamePrefix": "TEST_0001_WG_HG38_CRAM_MULTILANE",
-      "crosscheckFingerprintsCollector.sampleId": "TEST_0001_WG_HG38_CRAM_MULTILANE",
-      "crosscheckFingerprintsCollector.aligner": "bwa",
-      "crosscheckFingerprintsCollector.reference": "hg38",
-      "crosscheckFingerprintsCollector.filterBamLane.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamLane.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamLane.timeout": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.jobMemory": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.overhead": null,
-      "crosscheckFingerprintsCollector.filterBamPreSplit.timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapterTrimmingLog_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.indexBam_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.indexBam_modules": null,
-      "crosscheckFingerprintsCollector.bwaMem.indexBam_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.bamMerge_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.bamMerge_modules": null,
-      "crosscheckFingerprintsCollector.bwaMem.bamMerge_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.runBwaMem_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.runBwaMem_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.runBwaMem_threads": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapterTrimming_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapterTrimming_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapterTrimming_modules": null,
-      "crosscheckFingerprintsCollector.bwaMem.slicerR2_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.slicerR2_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.slicerR2_modules": null,
-      "crosscheckFingerprintsCollector.bwaMem.slicerR1_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.slicerR1_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.slicerR1_modules": null,
-      "crosscheckFingerprintsCollector.bwaMem.countChunkSize_timeout": null,
-      "crosscheckFingerprintsCollector.bwaMem.countChunkSize_jobMemory": null,
-      "crosscheckFingerprintsCollector.bwaMem.readGroups": null,
-      "crosscheckFingerprintsCollector.bwaMem.outputFileNamePrefix": null,
-      "crosscheckFingerprintsCollector.bwaMem.numChunk": null,
-      "crosscheckFingerprintsCollector.bwaMem.doTrim": null,
-      "crosscheckFingerprintsCollector.bwaMem.trimMinLength": null,
-      "crosscheckFingerprintsCollector.bwaMem.trimMinQuality": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapter1": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapter2": null,
-      "crosscheckFingerprintsCollector.bwaMem.runBwaMem_addParam": null,
-      "crosscheckFingerprintsCollector.bwaMem.adapterTrimming_addParam": null,
-      "crosscheckFingerprintsCollector.extractFingerprint.jobMemory": null,
-      "crosscheckFingerprintsCollector.extractFingerprint.timeout": null,
-      "crosscheckFingerprintsCollector.fastqR1": null,
-      "crosscheckFingerprintsCollector.fastqR2": null,
-      "crosscheckFingerprintsCollector.bam": null,
-      "crosscheckFingerprintsCollector.bamIndex": null,
-      "crosscheckFingerprintsCollector.star.outputFileNamePrefix": null,
-      "crosscheckFingerprintsCollector.star.runStar_addParam": null,
-      "crosscheckFingerprintsCollector.star.runStar_alignIntMax": null,
-      "crosscheckFingerprintsCollector.star.runStar_alignMatGapMax": null,
-      "crosscheckFingerprintsCollector.star.runStar_alignSJDBOvMin": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimJunOvMin": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimMulmapNmax": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimMulmapScoRan": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimNonchimScoDMin": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimOutJunForm": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimOutType": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimScoJunNonGTAG": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimScoreDropMax": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimScoreSeparation": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimSegmentReadGapMax": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimSegmin": null,
-      "crosscheckFingerprintsCollector.star.runStar_chimericjunctionSuffix": null,
-      "crosscheckFingerprintsCollector.star.runStar_genereadSuffix": null,
-      "crosscheckFingerprintsCollector.star.runStar_jobMemory": null,
-      "crosscheckFingerprintsCollector.star.runStar_multiMax": null,
-      "crosscheckFingerprintsCollector.star.runStar_outFilterMultimapNmax": null,
-      "crosscheckFingerprintsCollector.star.runStar_peOvMMp": null,
-      "crosscheckFingerprintsCollector.star.runStar_peOvNbasesMin": null,
-      "crosscheckFingerprintsCollector.star.runStar_saSparsed": null,
-      "crosscheckFingerprintsCollector.star.runStar_starSuffix": null,
-      "crosscheckFingerprintsCollector.star.runStar_threads": null,
-      "crosscheckFingerprintsCollector.star.runStar_timeout": null,
-      "crosscheckFingerprintsCollector.star.runStar_transcriptomeSuffix": null,
-      "crosscheckFingerprintsCollector.star.runStar_uniqMAPQ": null,
-      "crosscheckFingerprintsCollector.star.indexBam_modules": null,
-      "crosscheckFingerprintsCollector.star.indexBam_timeout": null,
-      "crosscheckFingerprintsCollector.star.indexBam_jobMemory": null,
-      "crosscheckFingerprintsCollector.maxReads": null,
-      "crosscheckFingerprintsCollector.downsample.jobMemory": null,
-      "crosscheckFingerprintsCollector.downsample.timeout": null,
-      "crosscheckFingerprintsCollector.markDups": true,
-      "crosscheckFingerprintsCollector.markDuplicates.timeout": null,
-      "crosscheckFingerprintsCollector.markDuplicates.jobMemory": 64,
-      "crosscheckFingerprintsCollector.markDuplicates.overhead": 6,
-      "crosscheckFingerprintsCollector.alignmentMetrics.timeout": null,
-      "crosscheckFingerprintsCollector.alignmentMetrics.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitStringToArray.threads": null,
-      "crosscheckFingerprintsCollector.splitStringToArray.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitStringToArray.lineSeparator": null,
-      "crosscheckFingerprintsCollector.splitStringToArray.modules": null,
-      "crosscheckFingerprintsCollector.splitStringToArray.recordSeparator": null,
-      "crosscheckFingerprintsCollector.splitStringToArray.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeBams.modules": null,
-      "crosscheckFingerprintsCollector.splitLanes.jobMemory": null,
-      "crosscheckFingerprintsCollector.splitLanes.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.additionalParams": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.jobMemory": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.overhead": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.threads": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.timeout": null,
-      "crosscheckFingerprintsCollector.mergeIntervalBams.modules": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.jobMemory": null,
-      "crosscheckFingerprintsCollector.fingerprintReadgroupInfo.timeout": null
-    },
-    "engineArguments": {
-      "write_to_cache": false,
-      "read_from_cache": false
-    },
-    "metadata": {
-      "crosscheckFingerprintsCollector.outputVcf": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_CRAM_MULTILANE@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.outputTbi": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_CRAM_MULTILANE@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.samstats": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_CRAM_MULTILANE@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.json": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_CRAM_MULTILANE@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
-      },
-      "crosscheckFingerprintsCollector.readgroupInfo": {
-        "contents": [
-          {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_crosscheckFingerprintsCollector_TEST_0001_WG_HG38_FASTQ@JENKINSID@"
-          }
-        ],
-        "type": "ALL"
-      }
-    },
-    "validators": [
-      {
-        "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
-        "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/1.2.1/TEST_0001_WG_HG38_CRAM_MULTILANE.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintsCollector/output_expectation/metrics/TEST_0001_WT_HG38_BAM.metrics",
         "type": "script"
       }
     ]
   }
 ]
-


### PR DESCRIPTION
Need to add hg38_noAlt to 1.2.0, version 1.2.1 turned out having CRAM inputs (somehow wrong commit was used to start a branch). Doing it again starting with 1.2.0. The updated version will be 1.2.2